### PR TITLE
Add Sentry Spring-boot support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     implementation("org.springframework.boot", "spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
     implementation(kotlin("stdlib"))
     runtimeOnly("mysql:mysql-connector-java")
     testCompile("com.google.truth.extensions", "truth-proto-extension", "1.1.2")

--- a/src/main/kotlin/com/yuanchenxi95/twig/framework/error_handlers/ApplicationErrorHandler.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/framework/error_handlers/ApplicationErrorHandler.kt
@@ -3,6 +3,7 @@ package com.yuanchenxi95.twig.framework.error_handlers
 import com.yuanchenxi95.protobuf.protobuf.api.TwigApiError
 import com.yuanchenxi95.twig.constants.DEFAULT_TWIG_INTERNAL_ERROR
 import com.yuanchenxi95.twig.constants.generateBadRequestError
+import io.sentry.Sentry
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.ResponseEntity
@@ -16,6 +17,8 @@ class ApplicationErrorHandler {
 
     @ExceptionHandler(value = [ServerWebInputException::class, UnsupportedMediaTypeStatusException::class])
     fun badRequestHandler(exception: Exception): ResponseEntity<TwigApiError> {
+        println(exception)
+        Sentry.captureException(exception)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .contentType(APPLICATION_JSON)
@@ -27,6 +30,7 @@ class ApplicationErrorHandler {
     @ExceptionHandler(value = [Exception::class])
     fun unknownExceptionHandler(exception: Exception): ResponseEntity<TwigApiError> {
         println(exception)
+        Sentry.captureException(exception)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .contentType(APPLICATION_JSON)

--- a/src/main/kotlin/com/yuanchenxi95/twig/framework/error_handlers/GlobalErrorHandler.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/framework/error_handlers/GlobalErrorHandler.kt
@@ -2,6 +2,7 @@ package com.yuanchenxi95.twig.framework.error_handlers
 
 import com.yuanchenxi95.twig.constants.DEFAULT_TWIG_INTERNAL_ERROR
 import com.yuanchenxi95.twig.framework.codecs.encodeProtobufValue
+import io.sentry.Sentry
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -13,6 +14,7 @@ import reactor.core.publisher.Mono
 class GlobalErrorHandler : ErrorWebExceptionHandler {
     override fun handle(serverWebExchange: ServerWebExchange, exception: Throwable): Mono<Void> {
         print(exception)
+        Sentry.captureException(exception)
         val response = serverWebExchange.response
         val bufferFactory = response.bufferFactory()
         response.headers.contentType = MediaType.APPLICATION_JSON

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,5 +11,8 @@ spring:
     username: 'twig'
     password: 'twig'
 
+sentry:
+  dsn: 'https://4a1d7adfa01f42ecad6092d0f3cd8466@o759320.ingest.sentry.io/5792476'
+
 twig:
   enableDatabaseCleanup: false


### PR DESCRIPTION
#3 

Add Sentry spring-boot support for capturing exceptions.
main page: https://sentry.io/organizations/twig-hp
Use google account to sign in


Basic usage:
```kotlin
Sentry.captureMessage("test")
try {
    throw Exception("This is a test.")
} catch (e: Exception) {
    Sentry.captureException(e)
}
```