### PR TITLE
Re-use testcontainer to speed up testing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,6 +27,14 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: setup re-use testcontainer
+        uses: DamianReeves/write-file-action
+        with:
+          path: ${{ env.home}}/.testcontainers.properties
+          contents: |
+            echo "testcontainers.reuse.enable=true"
+          write-mode: append
+
       - name:
           Build with Gradle
         uses: eskatos/gradle-command-action@v1

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@
 ```bash
 ./gradlew bootRun
 ```
+
+## Tests
+- To enable re-use testcontainer, which will increase test speed locally, add following line to `~/.testcontainers.properties` file:
+> :warning: RE-USE Testcontainer won't automatically shut down.
+
+```
+testcontainers.reuse.enable=true
+```
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -46,7 +46,7 @@ create table if not exists session
 create index _expiration_time_index
     on session (expiration_time desc);
 
-create event expiresession
+create event if not exists expiresession
     on schedule every 1 day
     do
     delete

--- a/src/test/kotlin/com/yuanchenxi95/twig/TwigApplicationTests.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/TwigApplicationTests.kt
@@ -2,8 +2,10 @@ package com.yuanchenxi95.twig
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
 
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class TwigApplicationTests {
     @Test
     fun contextLoads() {

--- a/src/test/kotlin/com/yuanchenxi95/twig/controllers/BookmarkControllerTests.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/controllers/BookmarkControllerTests.kt
@@ -13,10 +13,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.annotation.DirtiesContext
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BookmarkControllerTests {
 
     @MockBean

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     active: test
   r2dbc:
     # MySQL
-    url: 'r2dbc:tc:mysql://localhost:3306/twig?TC_IMAGE_TAG=8.0.25'
+    url: 'r2dbc:tc:mysql://localhost:3307/twig?TC_IMAGE_TAG=8.0.25&TC_REUSABLE=true'
     username: 'twig'
     password: 'twig'
   security:


### PR DESCRIPTION
- Enable reuse testcontainer feature to reduce test case execution time.
  - Before: ~ 10 min locally
  - After: ~ 1.5 min locally (clean start)