### PR TITLE
Add redis stream producer and consumer framework

### DIFF
--- a/src/main/kotlin/com/yuanchenxi95/twig/framework/database/RedisConfiguration.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/framework/database/RedisConfiguration.kt
@@ -3,6 +3,7 @@ package com.yuanchenxi95.twig.framework.database
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.yuanchenxi95.twig.models.StoredSession
+import com.yuanchenxi95.twig.models.StoredUrl
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -20,7 +21,7 @@ class RedisConfiguration {
     lateinit var factory: RedisConnectionFactory
 
     @Bean
-    fun reactiveRedisTemplate(
+    fun reactiveRedisTemplateForSession(
         reactiveRedisConnectionFactory: ReactiveRedisConnectionFactory?
     ): ReactiveRedisTemplate<String, StoredSession>? {
         val serializer: Jackson2JsonRedisSerializer<StoredSession> =
@@ -29,6 +30,21 @@ class RedisConfiguration {
 
         val builder =
             RedisSerializationContext.newSerializationContext<String, StoredSession>(StringRedisSerializer())
+
+        val context = builder.value(serializer).build()
+
+        return ReactiveRedisTemplate(reactiveRedisConnectionFactory!!, context)
+    }
+
+    @Bean
+    fun reactiveRedisTemplateForUrl(
+        reactiveRedisConnectionFactory: ReactiveRedisConnectionFactory?
+    ): ReactiveRedisTemplate<String, StoredUrl>? {
+        val serializer: Jackson2JsonRedisSerializer<StoredUrl> =
+            Jackson2JsonRedisSerializer(StoredUrl::class.java)
+
+        val builder =
+            RedisSerializationContext.newSerializationContext<String, StoredUrl>(StringRedisSerializer())
 
         val context = builder.value(serializer).build()
 

--- a/src/main/kotlin/com/yuanchenxi95/twig/framework/streams/RedisStreamConfig.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/framework/streams/RedisStreamConfig.kt
@@ -1,0 +1,68 @@
+package com.yuanchenxi95.twig.framework.streams
+
+import com.yuanchenxi95.twig.models.StoredUrl
+import io.lettuce.core.RedisBusyException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.RedisSystemException
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.connection.stream.ObjectRecord
+import org.springframework.data.redis.connection.stream.ReadOffset
+import org.springframework.data.redis.connection.stream.StreamOffset
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.stream.StreamListener
+import org.springframework.data.redis.stream.StreamMessageListenerContainer
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions
+import org.springframework.data.redis.stream.Subscription
+import java.net.InetAddress
+import java.time.Duration
+
+@Configuration
+class RedisStreamConfig {
+    @Value("\${streams.url.key}")
+    private lateinit var streamKey: String
+
+    @Value("\${streams.url.group}")
+    private lateinit var group: String
+
+    @Autowired
+    lateinit var streamListener: StreamListener<String, ObjectRecord<String, StoredUrl>>
+
+    @Autowired
+    lateinit var redisTemplate: ReactiveRedisTemplate<String, StoredUrl>
+
+    @Bean
+    fun subscription(redisConnectionFactory: RedisConnectionFactory?): Subscription {
+        try {
+            redisTemplate
+                .opsForStream<String, ObjectRecord<String, StoredUrl>>()
+                .createGroup(streamKey, group).block()
+        } catch (e: RedisSystemException) {
+            val cause = e.rootCause
+            if (cause != null && RedisBusyException::class.java == cause.javaClass) {
+                // TODO("Use logger instead of println")
+                println(
+                    "STREAM - Redis group already exists, skipping Redis group creation: {}"
+                )
+            } else throw e
+        }
+
+        val options = StreamMessageListenerContainerOptions
+            .builder()
+            .pollTimeout(Duration.ofSeconds(1))
+            .targetType(StoredUrl::class.java)
+            .build()
+        val listenerContainer = StreamMessageListenerContainer
+            .create(redisConnectionFactory, options)
+        val subscription = listenerContainer.receiveAutoAck(
+            Consumer.from(group, InetAddress.getLocalHost().hostName),
+            StreamOffset.create(streamKey, ReadOffset.lastConsumed()),
+            streamListener
+        )
+        listenerContainer.start()
+        return subscription
+    }
+}

--- a/src/main/kotlin/com/yuanchenxi95/twig/producermodules/bookmarks/CreateBookmarkProducerModule.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/producermodules/bookmarks/CreateBookmarkProducerModule.kt
@@ -9,6 +9,7 @@ import com.yuanchenxi95.twig.protobuf.api.CreateBookmarkRequest
 import com.yuanchenxi95.twig.protobuf.api.CreateBookmarkResponse
 import com.yuanchenxi95.twig.repositories.BookmarkRepository
 import com.yuanchenxi95.twig.repositories.UrlRepository
+import com.yuanchenxi95.twig.streams.UrlStreamProducer
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
 import org.springframework.data.relational.core.query.Criteria
@@ -34,6 +35,9 @@ class CreateBookmarkProducerModule {
     lateinit var bookmarkRepository: BookmarkRepository
 
     @Autowired
+    lateinit var urlStreamProducer: UrlStreamProducer
+
+    @Autowired
     lateinit var uuidUtils: UuidUtils
 
     private fun createUrl(url: String): Mono<StoredUrl> {
@@ -48,6 +52,8 @@ class CreateBookmarkProducerModule {
         )
         return r2dbcEntityTemplate.insert(storedUrl).flatMap {
             urlRepository.findById(nextId)
+        }.doOnNext {
+            urlStreamProducer.publishUrlEvent(it)
         }
     }
 

--- a/src/main/kotlin/com/yuanchenxi95/twig/streams/UrlStreamConsumer.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/streams/UrlStreamConsumer.kt
@@ -1,0 +1,16 @@
+package com.yuanchenxi95.twig.streams
+
+import com.yuanchenxi95.twig.models.StoredUrl
+import org.springframework.data.redis.connection.stream.ObjectRecord
+import org.springframework.data.redis.stream.StreamListener
+import org.springframework.stereotype.Service
+
+@Service
+class UrlStreamConsumer : StreamListener<String, ObjectRecord<String, StoredUrl>> {
+
+    override fun onMessage(message: ObjectRecord<String, StoredUrl>) {
+        // TODO("Use logger instead of println")
+        println("url:" + message.value.url)
+        // TODO("Add more logic")
+    }
+}

--- a/src/main/kotlin/com/yuanchenxi95/twig/streams/UrlStreamProducer.kt
+++ b/src/main/kotlin/com/yuanchenxi95/twig/streams/UrlStreamProducer.kt
@@ -1,0 +1,30 @@
+package com.yuanchenxi95.twig.streams
+
+import com.yuanchenxi95.twig.models.StoredUrl
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.connection.stream.StreamRecords
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class UrlStreamProducer {
+
+    @Value("\${streams.url.key}")
+    private lateinit var streamKey: String
+
+    @Autowired
+    private lateinit var redisTemplate: ReactiveRedisTemplate<String, StoredUrl>
+
+    fun publishUrlEvent(url: StoredUrl) {
+        val record = StreamRecords
+            .newRecord()
+            .`in`(streamKey)
+            .ofObject(url)
+
+        redisTemplate
+            .opsForStream<Any, Any>()
+            .add(record)
+            .subscribe()
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,8 @@ twig:
   enableDatabaseSetup: false
   showInternalServerError: true
   frontendDistDirectory: './frontend/dist/'
+
+streams:
+  url:
+    key: urlstream
+    group: inApp

--- a/src/test/kotlin/com/yuanchenxi95/twig/TwigApplicationTests.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/TwigApplicationTests.kt
@@ -6,7 +6,7 @@ import org.springframework.test.annotation.DirtiesContext
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-class TwigApplicationTests {
+class TwigApplicationTests : AbstractTestBase() {
     @Test
     fun contextLoads() {
     }

--- a/src/test/kotlin/com/yuanchenxi95/twig/annotations/MockDatabaseConfiguration.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/annotations/MockDatabaseConfiguration.kt
@@ -13,7 +13,10 @@ import org.springframework.test.annotation.DirtiesContext
 @AutoConfigureDataR2dbc
 @AutoConfigureDataRedis
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
-@ComponentScan("com.yuanchenxi95.twig.producermodules", "com.yuanchenxi95.twig.modelservices")
+@ComponentScan(
+    "com.yuanchenxi95.twig.producermodules",
+    "com.yuanchenxi95.twig.modelservices", "com.yuanchenxi95.twig.streams"
+)
 /** Mark the context as dirty after each test method. */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 annotation class MockDatabaseConfiguration

--- a/src/test/kotlin/com/yuanchenxi95/twig/controllers/BookmarkControllerTests.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/controllers/BookmarkControllerTests.kt
@@ -1,6 +1,7 @@
 package com.yuanchenxi95.twig.controllers
 
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.yuanchenxi95.twig.AbstractTestBase
 import com.yuanchenxi95.twig.data.API_BOOKMARK_1
 import com.yuanchenxi95.twig.producermodules.bookmarks.CreateBookmarkProducerModule
 import com.yuanchenxi95.twig.protobuf.api.CreateBookmarkRequest
@@ -19,7 +20,7 @@ import reactor.test.StepVerifier
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-class BookmarkControllerTests {
+class BookmarkControllerTests : AbstractTestBase() {
 
     @MockBean
     private lateinit var createBookmarkProducerModule: CreateBookmarkProducerModule

--- a/src/test/kotlin/com/yuanchenxi95/twig/repositories/BookmarkRepositoryTest.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/repositories/BookmarkRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.yuanchenxi95.twig.repositories
 
-import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest

--- a/src/test/kotlin/com/yuanchenxi95/twig/streams/UrlStreamProducerAndConsumerTest.kt
+++ b/src/test/kotlin/com/yuanchenxi95/twig/streams/UrlStreamProducerAndConsumerTest.kt
@@ -1,0 +1,52 @@
+package com.yuanchenxi95.twig.streams
+
+import com.google.common.truth.Truth.assertThat
+import com.yuanchenxi95.twig.AbstractTestBase
+import com.yuanchenxi95.twig.annotations.MockDatabaseConfiguration
+import com.yuanchenxi95.twig.data.STORED_URL_1
+import com.yuanchenxi95.twig.models.StoredUrl
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import reactor.test.StepVerifier
+
+@WebFluxTest(
+    excludeAutoConfiguration = [ReactiveUserDetailsServiceAutoConfiguration::class, ReactiveSecurityAutoConfiguration::class]
+)
+@MockDatabaseConfiguration
+@Import(
+    UrlStreamProducer::class, UrlStreamConsumer::class
+)
+class UrlStreamProducerAndConsumerTest : AbstractTestBase() {
+
+    @Autowired
+    lateinit var urlStreamProducer: UrlStreamProducer
+
+    @Autowired
+    lateinit var redisTemplate: ReactiveRedisTemplate<String, StoredUrl>
+
+    @Value("\${streams.url.key}")
+    private lateinit var streamKey: String
+
+    @Test
+    fun `Url stream produce once`() {
+
+        urlStreamProducer.publishUrlEvent(STORED_URL_1)
+
+        StepVerifier.create(redisTemplate.opsForStream<Any, Any>().size(streamKey))
+            .assertNext {
+                assertThat(it).isEqualTo(1)
+            }
+            .verifyComplete()
+    }
+
+    fun `Url stream produce and consume once`() {
+
+        TODO("Add test for consumer")
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -18,3 +18,8 @@ twig:
   enableDatabaseSetup: true
   showInternalServerError: true
   frontendDistDirectory: './frontend/dist/'
+
+streams:
+  url:
+    key: urlstreamtest
+    group: inApp


### PR DESCRIPTION
- Add redis stream producer and consumer framework
- Insert url to url stream when creating new url.

Existed problems:
- Lack of test for redis stream consumer, plan to use Mockito.verify to verify method call but failed.
- The stream consumer will keep trying to poll data. So for every test function, there'll be a connection lost exception.

For these existed problem, I'll keep tracking on, and maybe can find a better way to deal with.

Please review this function: `fun subscription(redisConnectionFactory: RedisConnectionFactory?): Subscription` not sure can I use block() directly here.